### PR TITLE
Enabling Smooth Scrolling for Parent Widget When `enableGestureTouch` is Disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 > [!IMPORTANT]  
 > See the [Migration Guide](guides/migration_guide.md) for the details of breaking changes between versions.
 
+## 3.0.4 (Unreleased)
+
+### Fixes
+
+- Fix `tiltConfig.enableGestureTouch` still prevents scrolling when disabled. ([#15](https://github.com/fluttercandies/flutter_tilt/pull/15))
+
 ## 3.0.3
 
 ### Improvements

--- a/lib/src/widget/gestures_listener.dart
+++ b/lib/src/widget/gestures_listener.dart
@@ -46,8 +46,8 @@ class _GesturesListenerState extends State<GesturesListener> {
   Widget build(BuildContext context) {
     /// 不受滑动影响
     return GestureDetector(
-      onVerticalDragUpdate: (_) {},
-      onHorizontalDragUpdate: (_) {},
+      onVerticalDragUpdate: _tiltConfig.enableGestureTouch ? (_) {} : null,
+      onHorizontalDragUpdate: _tiltConfig.enableGestureTouch ? (_) {} : null,
 
       /// 手势监听
       child: Listener(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: Easily apply tilt parallax hover effects for Flutter, which support
 # https://semver.org/spec/v2.0.0-rc.1.html
 # https://dart.dev/tools/pub/versioning#semantic-versions
 # https://dart.dev/tools/pub/dependencies#version-constraints
-version: 3.0.3
+version: 3.0.4
 homepage: https://amoshuke.github.io/flutter_tilt_book
 repository: https://github.com/fluttercandies/flutter_tilt
 issue_tracker: https://github.com/fluttercandies/flutter_tilt/issues


### PR DESCRIPTION
### Issue
* even when `enableGestureTouch` is disabled, the GestureDetector is still taking touch events, preventing scrolling within scrollable parent widgets.

--- 

Therefore, I've modified the following code to address the aforementioned issue

~~~
GestureDetector(
    onVerticalDragUpdate :  _tiltConfig.enableGestureTouch ?  (_) {} : null ,  
    onHorizontalDragUpdate :  _tiltConfig.enableGestureTouch ?  (_) {} : null ,  
    ...
~~~