### PR TITLE
Fix: `Tilt.disable: true` still prevents scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 > [!IMPORTANT]  
 > See the [Migration Guide](guides/migration_guide.md) for the details of breaking changes between versions.
 
+## 3.0.5
+
+### Fixes
+
+- Fix `Tilt.disable: true` still prevents scrolling.
+
 ## 3.0.4
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixes
 
-- Fix `Tilt.disable: true` still prevents scrolling.
+- Fix `Tilt.disable: true` still prevents scrolling. ([#16](https://github.com/fluttercandies/flutter_tilt/pull/16))
 
 ## 3.0.4
 

--- a/lib/src/tilt.dart
+++ b/lib/src/tilt.dart
@@ -176,6 +176,7 @@ class _TiltState extends State<Tilt> {
         _tiltStreamController ?? defaultTiltStreamController;
 
     return GesturesListener(
+      disable: _disable,
       tiltStreamController: tiltStreamController,
       tiltConfig: _tiltConfig,
       child: TiltStreamBuilder(

--- a/lib/src/widget/gestures_listener.dart
+++ b/lib/src/widget/gestures_listener.dart
@@ -15,11 +15,15 @@ class GesturesListener extends StatefulWidget {
   const GesturesListener({
     super.key,
     required this.child,
+    required this.disable,
     required this.tiltStreamController,
     required this.tiltConfig,
   });
 
   final Widget child;
+
+  /// 是否禁用
+  final bool disable;
 
   /// TiltStreamController
   final async.StreamController<TiltStreamModel> tiltStreamController;
@@ -32,6 +36,7 @@ class GesturesListener extends StatefulWidget {
 
 class _GesturesListenerState extends State<GesturesListener> {
   Widget get _child => widget.child;
+  bool get _disable => widget.disable;
   async.StreamController<TiltStreamModel> get _tiltStreamController =>
       widget.tiltStreamController;
   TiltConfig get _tiltConfig => widget.tiltConfig;
@@ -44,6 +49,8 @@ class _GesturesListenerState extends State<GesturesListener> {
 
   @override
   Widget build(BuildContext context) {
+    if (_disable) return _child;
+
     /// 不受滑动影响
     return GestureDetector(
       onVerticalDragUpdate: _tiltConfig.enableGestureTouch ? (_) {} : null,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: Easily apply tilt parallax hover effects for Flutter, which support
 # https://semver.org/spec/v2.0.0-rc.1.html
 # https://dart.dev/tools/pub/versioning#semantic-versions
 # https://dart.dev/tools/pub/dependencies#version-constraints
-version: 3.0.4
+version: 3.0.5
 homepage: https://amoshuke.github.io/flutter_tilt_book
 repository: https://github.com/fluttercandies/flutter_tilt
 issue_tracker: https://github.com/fluttercandies/flutter_tilt/issues

--- a/test/tilt_widget/tilt_config_test.dart
+++ b/test/tilt_widget/tilt_config_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_tilt/flutter_tilt.dart';
 import 'tilt_widget.dart';
@@ -13,21 +13,52 @@ void main() {
       expect(childFinder, findsOneWidget);
     });
     testWidgets('disable true', (WidgetTester tester) async {
-      TiltDataModel? tiltData;
-      GesturesType? gesturesType;
+      final ScrollController scrollController = ScrollController();
+
+      TiltDataModel? tiltDataTest;
+      GesturesType? gesturesTypeTest;
+
       await tester.pumpWidget(
-        TiltWidget(
-          disable: true,
-          onGestureMove: (TiltDataModel tiltData, GesturesType gesturesType) {
-            tiltData = tiltData;
-            gesturesType = gesturesType;
-          },
+        MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              controller: scrollController,
+              children: <Widget>[
+                Tilt(
+                  key: const Key('tilt_widget'),
+                  disable: true,
+                  child: const SizedBox(
+                    width: 100,
+                    height: 100,
+                    child: Text('Tilt'),
+                  ),
+                  onGestureMove: (
+                    TiltDataModel tiltData,
+                    GesturesType gesturesType,
+                  ) {
+                    tiltDataTest = tiltData;
+                    gesturesTypeTest = gesturesType;
+                  },
+                ),
+                const SizedBox(key: Key('scroll'), height: 100, width: 100),
+                const SizedBox(height: 1000),
+              ],
+            ),
+          ),
         ),
       );
-      await tester.fling(tiltWidgetFinder, const Offset(0.0, -5.0), 0.1);
+
+      /// onVerticalDragUpdate
+      await tester.timedDrag(
+        childFinder,
+        const Offset(0.0, -50.0),
+        const Duration(milliseconds: 1000),
+      );
+      await tester.pumpAndSettle();
       expect(childFinder, findsOneWidget);
-      expect(gesturesType, null);
-      expect(tiltData, null);
+      expect(scrollController.offset, 50.0);
+      expect(gesturesTypeTest, null);
+      expect(tiltDataTest, null);
     });
     testWidgets('fps', (WidgetTester tester) async {
       int count = 0;

--- a/test/tilt_widget/tilt_config_tilt_test.dart
+++ b/test/tilt_widget/tilt_config_tilt_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_tilt/flutter_tilt.dart';
 import 'tilt_widget.dart';
@@ -577,6 +577,55 @@ void main() {
       expect(tiltDataTest, tiltDataExpect);
 
       await tester.sendEventToBinding(testPointer.removePointer());
+    });
+    testWidgets('enableGestureTouch false - scrolling',
+        (WidgetTester tester) async {
+      final ScrollController scrollController = ScrollController();
+
+      TiltDataModel? tiltDataTest;
+      GesturesType? gesturesTypeTest;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              controller: scrollController,
+              children: <Widget>[
+                Tilt(
+                  key: const Key('tilt_widget'),
+                  tiltConfig: const TiltConfig(enableGestureTouch: false),
+                  child: const SizedBox(
+                    width: 100,
+                    height: 100,
+                    child: Text('Tilt'),
+                  ),
+                  onGestureMove: (
+                    TiltDataModel tiltData,
+                    GesturesType gesturesType,
+                  ) {
+                    tiltDataTest = tiltData;
+                    gesturesTypeTest = gesturesType;
+                  },
+                ),
+                const SizedBox(key: Key('scroll'), height: 100, width: 100),
+                const SizedBox(height: 1000),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      /// onVerticalDragUpdate
+      await tester.timedDrag(
+        childFinder,
+        const Offset(0.0, -50.0),
+        const Duration(milliseconds: 1000),
+      );
+      await tester.pumpAndSettle();
+      expect(childFinder, findsOneWidget);
+      expect(scrollController.offset, 50.0);
+      expect(gesturesTypeTest, null);
+      expect(tiltDataTest, null);
     });
     testWidgets('enableGestureHover false', (WidgetTester tester) async {
       TiltDataModel? tiltDataTest;


### PR DESCRIPTION
| Tilt.disable: false | Tilt.disable: true |
|---|---|
| <video src="https://github.com/user-attachments/assets/47b34f28-4209-4bb1-9937-6b4f05b73826"></video> | <video src="https://github.com/user-attachments/assets/a9316fc4-14b3-429c-9b21-51a2d9d336f2"></video> |
