### PR TITLE
Refactor: Replace Platform (dart:io) with TargetPlatform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 > [!IMPORTANT]  
 > See the [Migration Guide](guides/migration_guide.md) for the details of breaking changes between versions.
 
-## 3.0.6 (Unreleased)
+## 3.0.6
 
 ### Improvements
 
-- Handling when the platform has no available sensors.
+- Replace `Platform` (dart:io) with `TargetPlatform` (flutter/foundation.dart). ([#18](https://github.com/fluttercandies/flutter_tilt/pull/18))
+- Handling when the platform has no available sensors. ([#18](https://github.com/fluttercandies/flutter_tilt/pull/18))
 
 ## 3.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 > [!IMPORTANT]  
 > See the [Migration Guide](guides/migration_guide.md) for the details of breaking changes between versions.
 
+## 3.0.6 (Unreleased)
+
+### Improvements
+
+- Handling when the platform has no available sensors.
+
 ## 3.0.5
 
 ### Fixes

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/foundation.dart'
-    show kIsWeb, kIsWasm, defaultTargetPlatform, TargetPlatform;
+    show kIsWeb, defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/widgets.dart';
 
 import 'config/tilt_config.dart';
@@ -13,7 +13,7 @@ class Utils {
   ///
   /// @return [bool] true: 传感器支持 false: 传感器不支持
   static bool sensorsPlatformSupport() {
-    if (kIsWeb || kIsWasm) return true;
+    if (kIsWeb) return true;
     return switch (defaultTargetPlatform) {
       TargetPlatform.android => true,
       TargetPlatform.iOS => true,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,7 +1,7 @@
-import 'dart:io';
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart'
+    show kIsWeb, kIsWasm, defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/widgets.dart';
 
 import 'config/tilt_config.dart';
@@ -13,11 +13,12 @@ class Utils {
   ///
   /// @return [bool] true: 传感器支持 false: 传感器不支持
   static bool sensorsPlatformSupport() {
-    bool support = false;
-    if (kIsWeb) return support = true;
-    if (Platform.isAndroid) support = true;
-    if (Platform.isIOS) support = true;
-    return support;
+    if (kIsWeb || kIsWasm) return true;
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.android => true,
+      TargetPlatform.iOS => true,
+      _ => false
+    };
   }
 
   /// 区域中心定位

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: Easily apply tilt parallax hover effects for Flutter, which support
 # https://semver.org/spec/v2.0.0-rc.1.html
 # https://dart.dev/tools/pub/versioning#semantic-versions
 # https://dart.dev/tools/pub/dependencies#version-constraints
-version: 3.0.5
+version: 3.0.6
 homepage: https://amoshuke.github.io/flutter_tilt_book
 repository: https://github.com/fluttercandies/flutter_tilt
 issue_tracker: https://github.com/fluttercandies/flutter_tilt/issues

--- a/test/tilt_parallax_widget/tilt_parallax_test.dart
+++ b/test/tilt_parallax_widget/tilt_parallax_test.dart
@@ -112,6 +112,7 @@ void main() {
           ),
         ),
       );
+
       await tester.pumpAndSettle();
       final Offset outerLocation = tester.getCenter(outerFinder);
       final Offset innerLocation = tester.getCenter(innerFinder);

--- a/test/tilt_parallax_widget/tilt_parallax_widget.dart
+++ b/test/tilt_parallax_widget/tilt_parallax_widget.dart
@@ -46,7 +46,7 @@ class TiltParallaxWidget extends StatelessWidget {
               border: border,
               borderRadius: borderRadius,
               clipBehavior: clipBehavior,
-              tiltConfig: tiltConfig,
+              tiltConfig: tiltConfig.copyWith(enableGestureSensors: false),
               lightConfig: lightConfig,
               shadowConfig: shadowConfig,
               onGestureMove: onGestureMove,

--- a/test/tilt_widget/tilt_config_tilt_test.dart
+++ b/test/tilt_widget/tilt_config_tilt_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -585,6 +586,7 @@ void main() {
       TiltDataModel? tiltDataTest;
       GesturesType? gesturesTypeTest;
 
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -614,6 +616,7 @@ void main() {
           ),
         ),
       );
+      debugDefaultTargetPlatformOverride = null;
 
       /// onVerticalDragUpdate
       await tester.timedDrag(

--- a/test/tilt_widget/tilt_gestures_drag_test.dart
+++ b/test/tilt_widget/tilt_gestures_drag_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_tilt/flutter_tilt.dart';
@@ -8,6 +9,8 @@ void main() {
       final Finder childFinder = find.text('Tilt');
       final Finder scrollFinder = find.byKey(const Key('scroll'));
       final ScrollController scrollController = ScrollController();
+
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
 
       /// 回调赋值
       await tester.pumpWidget(
@@ -27,6 +30,7 @@ void main() {
           ),
         ),
       );
+      debugDefaultTargetPlatformOverride = null;
 
       /// onVerticalDragUpdate
       await tester.timedDrag(

--- a/test/tilt_widget/tilt_widget.dart
+++ b/test/tilt_widget/tilt_widget.dart
@@ -47,7 +47,7 @@ class TiltWidget extends StatelessWidget {
           border: border,
           borderRadius: borderRadius,
           clipBehavior: clipBehavior,
-          tiltConfig: tiltConfig,
+          tiltConfig: tiltConfig.copyWith(enableGestureSensors: false),
           lightConfig: lightConfig,
           shadowConfig: shadowConfig,
           onGestureMove: onGestureMove,

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_tilt/flutter_tilt.dart';
 import 'package:flutter_tilt/src/utils.dart';
@@ -16,7 +17,18 @@ void main() {
     const constraintsPosition = Utils.constraintsPosition;
 
     test('sensorsPlatformSupport', () {
-      expect(sensorsPlatformSupport(), false);
+      for (final TargetPlatform testTargetPlatform in TargetPlatform.values) {
+        debugDefaultTargetPlatformOverride = testTargetPlatform;
+        switch (testTargetPlatform) {
+          case TargetPlatform.android:
+            expect(sensorsPlatformSupport(), true);
+          case TargetPlatform.iOS:
+            expect(sensorsPlatformSupport(), true);
+          case _:
+            expect(sensorsPlatformSupport(), false);
+        }
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
 
     test('centerPosition', () {


### PR DESCRIPTION
## Description

- Replace `Platform` (dart:io) with `TargetPlatform` (flutter/foundation.dart).
- Handling when the platform has no available sensors.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I open this PR to the `main` branch.
- [ ] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.

## Breaking Change

Does your PR require package users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
