### PR TITLE
perf: reduce unnecessary animation controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
 > [!IMPORTANT]  
-> See the [Migration Guide](guides/migration_guide.md) for the details of breaking changes between versions.
+> See the [Migration Guide](https://github.com/fluttercandies/flutter_tilt/blob/main/guides/migration_guide.md) for the details of breaking changes between versions.
+
+## 3.3.1
+
+### Improvements
+
+- Reduce unnecessary animation controllers (multiple `TiltParallax` widgets share the same controller). ([#30](https://github.com/fluttercandies/flutter_tilt/pull/30))
 
 ## 3.3.0
 
@@ -16,7 +22,7 @@
 
   If you prefer to disable this effect:
 
-  ```diff
+  ```dart
   Tilt(
     tiltConfig: TiltConfig(
       enterToMoveDuration: Duration.zero,

--- a/lib/src/internal/mixin/tilt_tween_animation_mixin.dart
+++ b/lib/src/internal/mixin/tilt_tween_animation_mixin.dart
@@ -2,18 +2,18 @@ import 'package:flutter/widgets.dart';
 
 import '../../config/tilt_config.dart';
 import '../../enums.dart';
-import '../tilt_state.dart';
+import '../provider/tilt_provider.dart';
 
 mixin TiltTweenAnimationMixin<T extends StatefulWidget>
     on State<T>, TickerProviderStateMixin<T> {
   /// TiltTween 动画控制器
-  late AnimationController tiltTweenAnimationController;
+  late final AnimationController tiltTweenAnimationController;
 
   /// TiltTween 动画
   late Animation<Offset> tiltTweenAnimation;
 
   /// 从 Enter 过渡至 Move 的动画控制器
-  late AnimationController enterToMoveAnimationController;
+  late final AnimationController enterToMoveAnimationController;
 
   /// 标记是否处于进入动画状态
   bool _isEnter = false;
@@ -37,8 +37,8 @@ mixin TiltTweenAnimationMixin<T extends StatefulWidget>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final tiltState = TiltState.of(context);
-    _updateTiltTweenAnimation(tiltState);
+    final tiltProvider = TiltProvider.of(context);
+    _updateTiltTweenAnimation(tiltProvider);
     _didChangeDependencies = true;
   }
 
@@ -135,28 +135,28 @@ mixin TiltTweenAnimationMixin<T extends StatefulWidget>
   }
 
   /// 更新 TiltTween 动画
-  void _updateTiltTweenAnimation(TiltState tiltState) {
+  void _updateTiltTweenAnimation(TiltProvider tiltProvider) {
     final animationEnd = tiltTweenAnimationEnd(
-      tiltState.isMove,
-      tiltState.tiltConfig,
-      tiltState.areaProgress,
+      tiltProvider.isMove,
+      tiltProvider.tiltConfig,
+      tiltProvider.areaProgress,
     );
 
     /// 更新 enterToMoveAnimationController 的持续时间
     enterToMoveAnimationController.duration =
-        tiltState.tiltConfig.enterToMoveDuration;
+        tiltProvider.tiltConfig.enterToMoveDuration;
 
     if (tiltTweenAnimation.value == animationEnd) return;
 
     final animationDuration = tiltTweenAnimationDuration(
-      tiltState.isMove,
-      tiltState.currentGesturesType,
-      tiltState.tiltConfig,
+      tiltProvider.isMove,
+      tiltProvider.currentGesturesType,
+      tiltProvider.tiltConfig,
     );
     final animationCurve = tiltTweenAnimationCurve(
-      tiltState.isMove,
-      tiltState.currentGesturesType,
-      tiltState.tiltConfig,
+      tiltProvider.isMove,
+      tiltProvider.currentGesturesType,
+      tiltProvider.tiltConfig,
     );
 
     /// 更新 tiltTweenAnimationController 的持续时间
@@ -181,8 +181,8 @@ mixin TiltTweenAnimationMixin<T extends StatefulWidget>
 
     /// 避免 didChangeDependencies 和 build 的 updateTiltTweenAnimation 更新同步调用
     if (!_didChangeDependencies && enterToMoveAnimationController.isAnimating) {
-      final tiltState = TiltState.of(context);
-      _updateTiltTweenAnimation(tiltState);
+      final tiltProvider = TiltProvider.of(context);
+      _updateTiltTweenAnimation(tiltProvider);
       setState(() {});
     }
     _didChangeDependencies = false;

--- a/lib/src/internal/provider/tilt_animation_provider.dart
+++ b/lib/src/internal/provider/tilt_animation_provider.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/widgets.dart';
+
+class TiltAnimationProvider extends InheritedWidget {
+  const TiltAnimationProvider({
+    super.key,
+    required super.child,
+    required this.tiltTweenAnimation,
+  });
+
+  /// [TiltTweenAnimationMixin.tiltTweenAnimation]
+  final Animation<Offset> tiltTweenAnimation;
+
+  static TiltAnimationProvider of(BuildContext context) {
+    final tiltAnimationProvider =
+        context.dependOnInheritedWidgetOfExactType<TiltAnimationProvider>();
+    assert(
+      tiltAnimationProvider != null,
+      'No TiltAnimationProvider found in context',
+    );
+    return tiltAnimationProvider!;
+  }
+
+  @override
+  bool updateShouldNotify(TiltAnimationProvider oldWidget) =>
+      tiltTweenAnimation != oldWidget.tiltTweenAnimation;
+}

--- a/lib/src/internal/provider/tilt_provider.dart
+++ b/lib/src/internal/provider/tilt_provider.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/widgets.dart';
 
-import '../config/tilt_config.dart';
-import '../enums.dart';
+import '../../config/tilt_config.dart';
+import '../../enums.dart';
 
-/// Tilt State
-class TiltState extends InheritedWidget {
-  /// Tilt State
-  const TiltState({
+/// Tilt Base Provider
+class TiltProvider extends InheritedWidget {
+  /// Tilt Base Provider
+  const TiltProvider({
     super.key,
     required super.child,
     required this.isInit,
@@ -43,14 +43,15 @@ class TiltState extends InheritedWidget {
   /// 调整尺寸
   final void Function(Size) onResize;
 
-  static TiltState of(BuildContext context) {
-    final tiltState = context.dependOnInheritedWidgetOfExactType<TiltState>();
-    assert(tiltState != null, 'No TiltState found in context');
-    return tiltState!;
+  static TiltProvider of(BuildContext context) {
+    final tiltProvider =
+        context.dependOnInheritedWidgetOfExactType<TiltProvider>();
+    assert(tiltProvider != null, 'No TiltProvider found in context');
+    return tiltProvider!;
   }
 
   @override
-  bool updateShouldNotify(TiltState oldWidget) =>
+  bool updateShouldNotify(TiltProvider oldWidget) =>
       isInit != oldWidget.isInit ||
       width != oldWidget.width ||
       height != oldWidget.height ||

--- a/lib/src/tilt.dart
+++ b/lib/src/tilt.dart
@@ -1,5 +1,4 @@
 import 'dart:async' as async;
-
 import 'package:flutter/widgets.dart';
 
 import 'config/tilt_config.dart';
@@ -8,8 +7,8 @@ import 'config/tilt_shadow_config.dart';
 import 'enums.dart';
 import 'internal/controllers/fps_timer_controller.dart';
 import 'internal/controllers/tilt_gestures_controller.dart';
+import 'internal/provider/tilt_provider.dart';
 import 'internal/tilt_data.dart';
-import 'internal/tilt_state.dart';
 import 'models/tilt_stream_model.dart';
 import 'utils.dart';
 import 'widgets/gestures_listener.dart';
@@ -180,7 +179,7 @@ class _TiltState extends State<Tilt> {
         tiltGesturesController: _tiltGesturesController,
         builder: (context, snapshot) {
           _handleGesturesStream(snapshot.data);
-          return TiltState(
+          return TiltProvider(
             isInit: _isInit,
             width: _width,
             height: _height,

--- a/lib/src/widgets/tilt_container.dart
+++ b/lib/src/widgets/tilt_container.dart
@@ -5,8 +5,9 @@ import '../config/tilt_light_config.dart';
 import '../config/tilt_shadow_config.dart';
 import '../enums.dart';
 import '../internal/mixin/tilt_tween_animation_mixin.dart';
+import '../internal/provider/tilt_animation_provider.dart';
+import '../internal/provider/tilt_provider.dart';
 import '../internal/tilt_data.dart';
-import '../internal/tilt_state.dart';
 import 'tilt_light.dart';
 import 'tilt_shadow.dart';
 
@@ -87,39 +88,42 @@ class _TiltContainerState extends State<TiltContainer>
     with TickerProviderStateMixin, TiltTweenAnimationMixin {
   @override
   Widget build(BuildContext context) {
-    final tiltState = TiltState.of(context);
+    final tiltProvider = TiltProvider.of(context);
 
-    return AnimatedBuilder(
-      animation: tiltTweenAnimation,
-      builder: (BuildContext context, Widget? child) {
-        final areaProgress = tiltTweenAnimation.value;
+    return TiltAnimationProvider(
+      tiltTweenAnimation: tiltTweenAnimation,
+      child: AnimatedBuilder(
+        animation: tiltTweenAnimation,
+        builder: (BuildContext context, Widget? child) {
+          final areaProgress = tiltTweenAnimation.value;
 
-        final tiltData = TiltData(
-          isInit: tiltState.isInit,
-          width: tiltState.width,
-          height: tiltState.height,
-          areaProgress: areaProgress,
-          tiltConfig: widget.tiltConfig,
-        );
+          final tiltData = TiltData(
+            isInit: tiltProvider.isInit,
+            width: tiltProvider.width,
+            height: tiltProvider.height,
+            areaProgress: areaProgress,
+            tiltConfig: widget.tiltConfig,
+          );
 
-        return Transform(
-          alignment: AlignmentDirectional.center,
-          filterQuality: widget.tiltConfig.filterQuality,
-          transform: tiltData.transform,
-          child: Stack(
+          return Transform(
             alignment: AlignmentDirectional.center,
-            clipBehavior: Clip.none,
-            children: _buildLightShadowMode(
-              width: tiltState.width,
-              height: tiltState.height,
-              areaProgress: areaProgress,
-              onResize: tiltState.onResize,
-              child: child,
+            filterQuality: widget.tiltConfig.filterQuality,
+            transform: tiltData.transform,
+            child: Stack(
+              alignment: AlignmentDirectional.center,
+              clipBehavior: Clip.none,
+              children: _buildLightShadowMode(
+                width: tiltProvider.width,
+                height: tiltProvider.height,
+                areaProgress: areaProgress,
+                onResize: tiltProvider.onResize,
+                child: child,
+              ),
             ),
-          ),
-        );
-      },
-      child: widget.child,
+          );
+        },
+        child: widget.child,
+      ),
     );
   }
 

--- a/lib/src/widgets/tilt_parallax_container.dart
+++ b/lib/src/widgets/tilt_parallax_container.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/widgets.dart';
 
-import '../internal/mixin/tilt_tween_animation_mixin.dart';
-import '../internal/tilt_state.dart';
+import '../internal/provider/tilt_animation_provider.dart';
+import '../internal/provider/tilt_provider.dart';
 
 /// 倾斜视差
-class TiltParallaxContainer extends StatefulWidget {
+class TiltParallaxContainer extends StatelessWidget {
   /// 倾斜视差
   ///
   /// 用作视差的 Widget
@@ -25,31 +25,27 @@ class TiltParallaxContainer extends StatefulWidget {
   final FilterQuality? filterQuality;
 
   @override
-  State<TiltParallaxContainer> createState() => _TiltParallaxContainerState();
-}
-
-class _TiltParallaxContainerState extends State<TiltParallaxContainer>
-    with TickerProviderStateMixin, TiltTweenAnimationMixin {
-  @override
   Widget build(BuildContext context) {
-    final tiltState = TiltState.of(context);
+    final tiltAnimationProvider = TiltAnimationProvider.of(context);
+    final tiltTweenAnimationProvider = tiltAnimationProvider.tiltTweenAnimation;
+    final tiltProvider = TiltProvider.of(context);
 
     return AnimatedBuilder(
-      animation: tiltTweenAnimation,
+      animation: tiltTweenAnimationProvider,
       builder: (BuildContext context, Widget? child) {
-        final areaProgress = tiltTweenAnimation.value;
+        final areaProgress = tiltTweenAnimationProvider.value;
 
         return Transform(
-          filterQuality: widget.filterQuality,
+          filterQuality: filterQuality,
           transform: tiltParallaxTransform(
             areaProgress,
-            widget.size,
-            tiltState.tiltConfig.enableReverse,
+            size,
+            tiltProvider.tiltConfig.enableReverse,
           ),
           child: child,
         );
       },
-      child: widget.child,
+      child: child,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: Easily apply tilt parallax hover effects for Flutter, which support
 # https://semver.org/spec/v2.0.0-rc.1.html
 # https://dart.dev/tools/pub/versioning#semantic-versions
 # https://dart.dev/tools/pub/dependencies#version-constraints
-version: 3.3.0
+version: 3.3.1
 homepage: https://amoshuke.github.io/flutter_tilt_book
 repository: https://github.com/fluttercandies/flutter_tilt
 issue_tracker: https://github.com/fluttercandies/flutter_tilt/issues

--- a/test/internal/mixin/tilt_tween_animation_mixin_test.dart
+++ b/test/internal/mixin/tilt_tween_animation_mixin_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_tilt/src/config/tilt_config.dart';
 import 'package:flutter_tilt/src/enums.dart';
 import 'package:flutter_tilt/src/internal/mixin/tilt_tween_animation_mixin.dart';
-import 'package:flutter_tilt/src/internal/tilt_state.dart';
+import 'package:flutter_tilt/src/internal/provider/tilt_provider.dart';
 
 void main() {
   group('TiltTweenAnimationMixin ::', () {
@@ -217,7 +217,7 @@ class TiltTweenAnimationMixinTestWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TiltState(
+    return TiltProvider(
       tiltConfig: const TiltConfig(),
       isInit: true,
       width: 10.0,


### PR DESCRIPTION
## Description

Reduce unnecessary animation controllers (multiple `TiltParallax` widgets share the same controller).

Frame Time (UI) on the Windows desktop platform (Profile mode):
| Number of widgets (TiltParallax) | Before | After |
| --- | --- | --- |
| 5000 widgets | max ~63 ms/frame<br>avg ~30 ms/frame | max ~28 ms/frame<br>avg ~16 ms/frame |
| 1000 widgets | max ~9 ms/frame<br>avg ~6 ms/frame | max ~6 ms/frame<br>avg ~3 ms/frame |
| 100 widgets | max ~2 ms/frame<br>avg ~0.8 ms/frame | max ~1 ms/frame<br>avg ~0.6 ms/frame |

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).

- [x] I open this PR to the `main` branch.
- [ ] I did not modify the `CHANGELOG.md` nor the package version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.

## Breaking Change

Does your PR require package users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
